### PR TITLE
Add deleted consoleCommandSender argument

### DIFF
--- a/Hagot/src/main/java/me/hakej/hagot/hagot/Hagot.java
+++ b/Hagot/src/main/java/me/hakej/hagot/hagot/Hagot.java
@@ -5,7 +5,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public final class Hagot extends JavaPlugin {
 
-    private ConsolePrinter consolePrinter = new ConsolePrinter(this);
+    private ConsolePrinter consolePrinter = new ConsolePrinter(getServer().getConsoleSender(), this);
     private MyEvents myEvents = new MyEvents(this);
 
     @Override


### PR DESCRIPTION
Add deleted ConsoleCommandSender argument in ConsolePrinter initialization. It was deleted due to future ConsolePrinter refactor.